### PR TITLE
Refactor dual mesh to use TriangleId for corner indexing

### DIFF
--- a/src/dual-mesh.test.ts
+++ b/src/dual-mesh.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vite-plus/test";
 
-import { type CornerId, DualMesh, type EdgeId, type TriangleId } from "./dual-mesh";
+import { DualMesh, type EdgeId, type TriangleId } from "./dual-mesh";
 import { pointCount, pointX, pointY, type PointId } from "./utils/point-buffer";
 
 function asPointId(value: number): PointId {
@@ -13,10 +13,6 @@ function asEdgeId(value: number): EdgeId {
 
 function asTriangleId(value: number): TriangleId {
   return value as TriangleId;
-}
-
-function asCornerId(value: number): CornerId {
-  return value as CornerId;
 }
 
 function fixturePoints(): Float64Array {
@@ -39,8 +35,8 @@ test("point-buffer helpers work with mesh points and corners", () => {
   expect(pointY(mesh.points, asPointId(4))).toBe(1);
 
   expect(pointCount(mesh.corners)).toBe(4);
-  expect(pointX(mesh.corners, asCornerId(2))).toBe(2);
-  expect(pointY(mesh.corners, asCornerId(2))).toBeCloseTo(2 / 3);
+  expect(pointX(mesh.corners, asTriangleId(2))).toBe(2);
+  expect(pointY(mesh.corners, asTriangleId(2))).toBeCloseTo(2 / 3);
 });
 
 test("edge topology helpers match the fixed triangulation", () => {
@@ -60,19 +56,18 @@ test("edge topology helpers match the fixed triangulation", () => {
   expect(mesh.edgeOpposite(asEdgeId(1))).toBeNull();
 });
 
-test("triangle and corner ids map one-to-one", () => {
+test("triangle ids index the dual corners buffer directly", () => {
   const mesh = new DualMesh(fixturePoints());
 
-  expect(mesh.triangleCorner(asTriangleId(3))).toBe(3);
-  expect(mesh.cornerTriangle(asCornerId(3))).toBe(3);
+  expect(pointX(mesh.corners, asTriangleId(3))).toBeCloseTo(4 / 3);
+  expect(pointY(mesh.corners, asTriangleId(3))).toBeCloseTo(4 / 3);
 });
 
-test("id iterators expose all branded edge, triangle, and corner ids", () => {
+test("id iterators expose all branded edge and triangle ids", () => {
   const mesh = new DualMesh(fixturePoints());
 
   expect(Array.from(mesh.edgeIds())).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   expect(Array.from(mesh.triangleIds())).toEqual([0, 1, 2, 3]);
-  expect(Array.from(mesh.cornerIds())).toEqual([0, 1, 2, 3]);
 });
 
 test("triangle traversal helpers preserve raw Delaunator-derived order", () => {

--- a/src/dual-mesh.ts
+++ b/src/dual-mesh.ts
@@ -1,11 +1,10 @@
 import Delaunator from "delaunator";
 
 import type { Brand } from "./utils/brand";
-import { pointIds, pointX, pointY, type PointBuffer, type PointId } from "./utils/point-buffer";
+import { pointX, pointY, type PointBuffer, type PointId } from "./utils/point-buffer";
 
-export type TriangleId = Brand<number, "TriangleId">;
+export type TriangleId = Brand<PointId, "TriangleId">;
 export type EdgeId = Brand<number, "EdgeId">;
-export type CornerId = Brand<PointId, "CornerId">;
 
 const TRIANGLE_STRIDE = 3;
 
@@ -23,6 +22,7 @@ export class DualMesh {
   static edgeTriangle(edge: EdgeId): TriangleId {
     return Math.floor(edge / TRIANGLE_STRIDE) as TriangleId;
   }
+
   readonly points: PointBuffer;
   readonly corners: PointBuffer;
 
@@ -35,7 +35,7 @@ export class DualMesh {
       this.triangleIds().flatMap((t) => {
         let cx = 0;
         let cy = 0;
-        for (const point of this.trianglePoints(t as TriangleId)) {
+        for (const point of this.trianglePoints(t)) {
           cx += pointX(this.points, point);
           cy += pointY(this.points, point);
         }
@@ -57,14 +57,6 @@ export class DualMesh {
     return this.#delaunator.triangles[DualMesh.nextEdge(edge)] as PointId;
   }
 
-  triangleCorner(triangle: TriangleId): CornerId {
-    return triangle as CornerId;
-  }
-
-  cornerTriangle(corner: CornerId): TriangleId {
-    return corner as TriangleId;
-  }
-
   *edgeIds(): Generator<EdgeId> {
     for (let edge = 0; edge < this.#delaunator.triangles.length; edge++) {
       yield edge as EdgeId;
@@ -76,10 +68,6 @@ export class DualMesh {
     for (let triangle = 0; triangle < triangleCount; triangle++) {
       yield triangle as TriangleId;
     }
-  }
-
-  cornerIds(): Generator<CornerId> {
-    return pointIds(this.corners) as Generator<CornerId>;
   }
 
   *triangleEdges(triangle: TriangleId): Generator<EdgeId> {

--- a/src/offscreen-worker.ts
+++ b/src/offscreen-worker.ts
@@ -47,12 +47,7 @@ function render({ data: { canvas } }: MessageEvent<OffscreenWorkerMessage>): voi
     if (opposite === null) {
       continue;
     }
-    addSegment(
-      duals,
-      mesh.corners,
-      mesh.triangleCorner(DualMesh.edgeTriangle(edge)),
-      mesh.triangleCorner(DualMesh.edgeTriangle(opposite)),
-    );
+    addSegment(duals, mesh.corners, DualMesh.edgeTriangle(edge), DualMesh.edgeTriangle(opposite));
   }
   ctx.strokeStyle = DELAUNAY_STROKE_STYLE;
   ctx.lineWidth = STROKE_SIZE;


### PR DESCRIPTION
## Summary
- make `TriangleId` extend `PointId` so triangle ids can index the dual corners buffer directly
- remove the separate `CornerId` type and the related conversion helpers
- update dual mesh rendering and tests to use `TriangleId` for corner access

## Testing
- `vp check`
- `vp test`